### PR TITLE
add version parameter for auto updates + code cleanup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,10 @@
 class jenkins(
-        $to_port    = $jenkins::params::to_port
+  $to_port    = $jenkins::params::to_port,
+  $version    = $jenkins::params::version,
 
 ) inherits jenkins::params{
 
-        include jenkins::install
-        include jenkins::service
-        include jenkins::routing
+  include jenkins::install
+  include jenkins::service
+  include jenkins::routing
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,23 +1,23 @@
 class jenkins::install inherits jenkins{
 
-       exec{'download':
-             command      =>  'wget -O /etc/yum.repos.d/jenkins.repo http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo',
-             path         =>  '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-             cwd          =>  '/etc/yum.repos.d',
-             user         =>  'root',
-             creates      =>  '/etc/yum.repos.d/jenkins.repo',
-             notify       =>  Exec['extract'],
-       }
+  exec{'download':
+    command =>  'wget -O /etc/yum.repos.d/jenkins.repo http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo',
+    path    =>  '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    cwd     =>  '/etc/yum.repos.d',
+    user    =>  'root',
+    creates =>  '/etc/yum.repos.d/jenkins.repo',
+    notify  =>  Exec['extract'],
+  }
 
-       exec{'extract':
-             command      =>  'rpm --import http://pkg.jenkins-ci.org/redhat-stable/jenkins-ci.org.key',
-             path         =>  '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-             cwd          =>  '/etc/yum.repos.d',
-             user         =>  'root',
-             refreshonly  =>  true,
-       }
+  exec{'extract':
+    command     =>  'rpm --import http://pkg.jenkins-ci.org/redhat-stable/jenkins-ci.org.key',
+    path        =>  '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    cwd         =>  '/etc/yum.repos.d',
+    user        =>  'root',
+    refreshonly =>  true,
+  }
 
-       package{'jenkins':
-             ensure       =>  installed,
-       }
+  package{'jenkins':
+    ensure  => $::version
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,5 @@
 class jenkins::params{
 
-      $to_port    = '80'
+  $to_port    = '80'
+  $version    = 'latest'
 }

--- a/manifests/routing.pp
+++ b/manifests/routing.pp
@@ -1,7 +1,7 @@
 class jenkins::routing inherits jenkins{
-       exec{'routing':
-               command   =>  "iptables -A PREROUTING -t nat -i eth0 -p tcp --dport $::jenkins::to_port -j REDIRECT --to-port 8080",
-               path      =>  '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-               user      =>  'root',
-       }
+  exec{'routing':
+    command =>  "iptables -A PREROUTING -t nat -i eth0 -p tcp --dport ${::jenkins::to_port} -j REDIRECT --to-port 8080",
+    path    =>  '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    user    =>  'root',
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,6 @@
 class jenkins::service inherits jenkins{
-       
-       service{'jenkins':
-              ensure   =>  running,
-       }
+
+  service{'jenkins':
+    ensure   =>  running,
+  }
 }


### PR DESCRIPTION
I was using your module for a small Jenkins setup, but noticed it was rather difficult to keep the Jenkins version up-to-date.
So, I added a version parameter to your code so it can be set to latest (default value) and install the most recent Jenkins version automatically without manual intervention.